### PR TITLE
Run CI without C exts lock on TruffleRuby

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -21,7 +21,7 @@ jobs:
         
         include:
           - os: ubuntu
-            ruby: truffleruby
+            ruby: truffleruby-head
             experimental: true
           - os: ubuntu
             ruby: jruby


### PR DESCRIPTION
* Fixes https://github.com/socketry/event/issues/2

I want to see if CI passes with this.