### PR TITLE
Add process wait support.

### DIFF
--- a/ext/event/backend/backend.c
+++ b/ext/event/backend/backend.c
@@ -20,18 +20,22 @@
 
 #include "backend.h"
 
-static ID id_transfer, id_alive_p;
-
-void Init_Event_Backend(VALUE Event_Backend) {
-	id_transfer = rb_intern("transfer");
-	id_alive_p = rb_intern("alive?");
-}
-
+// On macOS
 #if HAVE_RB_FIBER_TRANSFER_KW
 #define HAVE_RB_FIBER_TRANSFER 1
 #else
 #define HAVE_RB_FIBER_TRANSFER 0
 #endif
+
+static ID id_transfer, id_wait;
+static VALUE rb_Process_Status = Qnil;
+
+void Init_Event_Backend(VALUE Event_Backend) {
+	id_transfer = rb_intern("transfer");
+	id_wait = rb_intern("wait");
+	// id_alive_p = rb_intern("alive?");
+	rb_Process_Status = rb_const_get_at(rb_mProcess, rb_intern("Status"));
+}
 
 VALUE
 Event_Backend_transfer(VALUE fiber) {
@@ -53,4 +57,9 @@ Event_Backend_transfer_result(VALUE fiber, VALUE result) {
 #else
 	return rb_funcall(fiber, id_transfer, 1, result);
 #endif
+}
+
+VALUE Event_Backend_process_status_wait(rb_pid_t pid)
+{
+	return rb_funcall(rb_Process_Status, id_wait, 2, PIDT2NUM(pid), INT2NUM(WNOHANG));
 }

--- a/ext/event/backend/backend.c
+++ b/ext/event/backend/backend.c
@@ -20,7 +20,6 @@
 
 #include "backend.h"
 
-// On macOS
 #if HAVE_RB_FIBER_TRANSFER_KW
 #define HAVE_RB_FIBER_TRANSFER 1
 #else

--- a/ext/event/backend/backend.h
+++ b/ext/event/backend/backend.h
@@ -34,3 +34,5 @@ Init_Event_Backend();
 
 VALUE Event_Backend_transfer(VALUE fiber);
 VALUE Event_Backend_transfer_result(VALUE fiber, VALUE argument);
+
+VALUE Event_Backend_process_status_wait(rb_pid_t pid);

--- a/ext/event/backend/epoll.c
+++ b/ext/event/backend/epoll.c
@@ -24,8 +24,6 @@
 #include <sys/epoll.h>
 #include <time.h>
 #include <errno.h>
-#include <sys/types.h>
-#include <sys/wait.h>
 
 #include "pidfd.c"
 

--- a/ext/event/backend/kqueue.c
+++ b/ext/event/backend/kqueue.c
@@ -23,8 +23,6 @@
 
 #include <sys/event.h>
 #include <sys/ioctl.h>
-#include <sys/types.h>
-#include <sys/wait.h>
 #include <time.h>
 #include <errno.h>
 

--- a/ext/event/backend/pidfd.c
+++ b/ext/event/backend/pidfd.c
@@ -1,0 +1,36 @@
+// Copyright, 2021, by Samuel G. D. Williams. <http://www.codeotaku.com>
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <sys/types.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <poll.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#ifndef __NR_pidfd_open
+#define __NR_pidfd_open 434   /* System call # on most architectures */
+#endif
+
+static int
+pidfd_open(pid_t pid, unsigned int flags)
+{
+	return syscall(__NR_pidfd_open, pid, flags);
+}

--- a/ext/event/extconf.rb
+++ b/ext/event/extconf.rb
@@ -33,6 +33,7 @@ $CFLAGS << " -Wall"
 $srcs = ["event.c", "backend/backend.c"]
 $VPATH << "$(srcdir)/backend"
 
+# have_func('rb_fiber_transfer')
 have_func('rb_fiber_transfer_kw')
 
 if have_library('uring') and have_header('liburing.h')

--- a/lib/event/backend/select.rb
+++ b/lib/event/backend/select.rb
@@ -52,6 +52,11 @@ module Event
 				@readable.delete(io) if remove_readable
 				@writable.delete(io) if remove_writable
 			end
+
+			def process_wait(fiber, pid, flags)
+				val = Process::Status.wait(pid, flags)
+				fiber.transfer(val)
+			end
 			
 			def select(duration = nil)
 				readable, writable, _ = ::IO.select(@readable.keys, @writable.keys, nil, duration)

--- a/spec/event/selector_examples.rb
+++ b/spec/event/selector_examples.rb
@@ -199,7 +199,7 @@ RSpec.shared_examples_for Event::Selector do
 				sleep(1)
 				
 				result = subject.process_wait(Fiber.current, pid, 0)
-				pp result
+				expect(result).to be_success
 				events << :process_finished
 			end
 			
@@ -218,7 +218,7 @@ RSpec.shared_examples_for Event::Selector do
 			fiber = Fiber.new do
 				pid = Process.spawn("sleep 1")
 				result = subject.process_wait(Fiber.current, pid, 0)
-				pp result
+				expect(result).to be_success
 				events << :process_finished
 			end
 			

--- a/spec/event/selector_examples.rb
+++ b/spec/event/selector_examples.rb
@@ -185,4 +185,25 @@ RSpec.shared_examples_for Event::Selector do
 			]
 		end
 	end
+
+	describe '#process_wait' do
+		let!(:loop) {Fiber.current}
+		subject{described_class.new(loop)}
+
+		it "can wait for an process to terminate" do
+			result = nil
+			events = []
+
+			fiber = Fiber.new do
+				pid = Process.spawn("true")
+				result = subject.process_wait(Fiber.current, pid, 0)
+				events << :process_finished
+			end
+
+			fiber.transfer
+			subject.select(0)
+			expect(events).to be == [:process_finished]
+			expect(result.success?).to be == true
+		end
+	end
 end


### PR DESCRIPTION
## Description

This builds on existing work by @dsh0416.

- Implement native `kqueue` `NOTE_EXIT` filter.
- Rework `pidfd` for `epoll` and `uring` to deal with exceptional flow control.
- Notification pipe for `select` implementation.

### Types of Changes

- New feature.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [ ] I tested my changes locally.
