### PR TITLE
Prefixing & should avoid checking for the symbol itself.

### DIFF
--- a/ext/event/backend/backend.c
+++ b/ext/event/backend/backend.c
@@ -20,12 +20,6 @@
 
 #include "backend.h"
 
-#if HAVE_RB_FIBER_TRANSFER_KW
-#define HAVE_RB_FIBER_TRANSFER 1
-#else
-#define HAVE_RB_FIBER_TRANSFER 0
-#endif
-
 static ID id_transfer, id_wait;
 static VALUE rb_Process_Status = Qnil;
 
@@ -38,7 +32,7 @@ void Init_Event_Backend(VALUE Event_Backend) {
 
 VALUE
 Event_Backend_transfer(VALUE fiber) {
-#if HAVE_RB_FIBER_TRANSFER
+#ifdef HAVE__RB_FIBER_TRANSFER
 	return rb_fiber_transfer(fiber, 0, NULL);
 #else
 	return rb_funcall(fiber, id_transfer, 0);
@@ -51,7 +45,7 @@ Event_Backend_transfer_result(VALUE fiber, VALUE result) {
 	// 	return Qnil;
 	// }
 	
-#if HAVE_RB_FIBER_TRANSFER
+#ifdef HAVE__RB_FIBER_TRANSFER
 	return rb_fiber_transfer(fiber, 1, &result);
 #else
 	return rb_funcall(fiber, id_transfer, 1, result);

--- a/ext/event/extconf.rb
+++ b/ext/event/extconf.rb
@@ -33,8 +33,7 @@ $CFLAGS << " -Wall"
 $srcs = ["event.c", "backend/backend.c"]
 $VPATH << "$(srcdir)/backend"
 
-# have_func('rb_fiber_transfer')
-have_func('rb_fiber_transfer_kw')
+have_func('&rb_fiber_transfer')
 
 if have_library('uring') and have_header('liburing.h')
 	$srcs << "backend/uring.c"


### PR DESCRIPTION
## Description

After discussing it with @eregon, apparently prefixing & should fix the macOS `have_func` from passing.

### Types of Changes

- Bug fix.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I tested my changes locally.
