### PR TITLE
General implementation of `io_read` and `io_write`.

### DIFF
--- a/ext/event/backend/backend.h
+++ b/ext/event/backend/backend.h
@@ -36,3 +36,10 @@ VALUE Event_Backend_transfer(VALUE fiber);
 VALUE Event_Backend_transfer_result(VALUE fiber, VALUE argument);
 
 VALUE Event_Backend_process_status_wait(rb_pid_t pid);
+
+char* Event_Backend_verify_size(VALUE buffer, size_t offset, size_t length);
+char* Event_Backend_resize_to_capacity(VALUE string, size_t offset, size_t length);
+void Event_Backend_resize_to_fit(VALUE string, size_t offset, size_t length);
+
+int Event_Backend_nonblock_set(int file_descriptor);
+void Event_Backend_nonblock_restore(int file_descriptor, int flags);


### PR DESCRIPTION
## Description

Provide implementations for `io_read` and `io_write` for all selectors. For `uring`, this is a native code path with fallback to `io_wait` on `EAGAIN`. For all other implementations, it's implemented by using non-blocking I/O in a loop.

### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
